### PR TITLE
Don't #[allow(type_alias_bounds)].

### DIFF
--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code, type_alias_bounds)]
+#![allow(dead_code)]
 
 //! Define Matrix calculations.
 
@@ -7,7 +7,7 @@ extern crate num;
 
 use vector::scal_vec_prod;
 
-pub type Mat<T: num::traits::Num + std::fmt::Display + Copy> = Vec<Vec<T>>;
+pub type Mat<T> = Vec<Vec<T>>;
 
 fn mk_mat<T>(vs: Vec<Vec<T>>) -> Option<Mat<T>> {
     let l0 = vs[0].len();


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/54090 will fix false positives (not relevant here) and make it an error in the upcoming Rust 2018 edition, which means that if you want to migrate to Rust 2018, it shouldn't be ignored.

See also https://github.com/rust-lang/rust/issues/49441#issuecomment-421136550 for the decision and some background.